### PR TITLE
Adding some improvements to ceph-flocker-driver

### DIFF
--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+Ceph driver for flocker

--- a/ceph_flocker_driver/__init__.py
+++ b/ceph_flocker_driver/__init__.py
@@ -4,7 +4,7 @@ from .ceph_rbd import (
     DEFAULT_CEPF_CONF_PATH, DEFAULT_STORAGE_POOL
 )
 
-def api_factory(cluster_id, test_case, **kwargs):
+def api_factory(cluster_id, test_case=None, **kwargs):
 
     cluster_name = DEFAULT_CLUSTER_NAME
     if "cluster_name" in kwargs:

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,6 @@ setup(
 
     keywords='backend, plugin, flocker, docker, python',
     packages=find_packages(exclude=['test*']),
-    install_requires = ['rados'],
+    install_requires = ['python-cephlibs'],
     data_files=[('/etc/flocker/', ['agent.yml.example'])],
 )


### PR DESCRIPTION
Following installation guide I found out that DESCRIPTION.rst is missing in main directory. 
Changing required package from rados to python-cephlibs allows to install rados.py using pip.
Making test_case default value to None makes it not necessary to include test_case in cluster.yml flocker configuration.
